### PR TITLE
fix: Error when using memcpy - will read garbage memory under load

### DIFF
--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -966,14 +966,13 @@ static char *handle_cli_redis_show(struct ast_cli_entry *e, int cmd, struct ast_
                 } else {
                     char *value = get_reply_value_as_str(get_reply);
                     if (value) {
-                        ast_cli(args->fd, "%-50s: %-25s\n", reply->element[i]->str, value);
+                        ast_cli(args->fd, "%-50s: %-25s\n", get_reply->element[i]->str, value);
                         ast_free(value);
                     }
                 }
+                freeReplyObject(get_reply);
             }
-            freeReplyObject(get_reply);
         }
-
         ast_cli(args->fd, "%d results found.\n", (int) reply->elements);
     }
     freeReplyObject(reply);

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -162,20 +162,32 @@ snprintf (__log_buffer, __LOG_BUFFER_SZ, __VA_ARGS__); \
 ast_debug(1, "%s\n", __log_buffer);
 
 
-#define get_safe_redis_context_for_func_as(name) redisContext * name = NULL;\
-if (!(redis_context = ast_threadstorage_get(&redis_instance, sizeof(redisContext))))\
-{\
-ast_log(LOG_ERROR, "Error retrieving the redis context from thread\n");\
-return -1;\
-}\
+/* For dial-plan functions (return –1 on failure) */
+#define get_safe_redis_context_for_func_as(name)                     \
+    redisContext *name = NULL;                                       \
+    do {                                                             \
+        redisContext **__pp =                                        \
+            ast_threadstorage_get(&redis_instance, sizeof(void *));  \
+        if (!__pp || !(*__pp)) {                                     \
+            ast_log(LOG_ERROR, "No redis context in thread\n");      \
+            return -1;                                               \
+        }                                                            \
+        name = *__pp;                                                \
+    } while (0)
 
 
-#define get_safe_redis_context_for_cli_as(name) redisContext * name = NULL;\
-if (!(redis_context = ast_threadstorage_get(&redis_instance, sizeof(redisContext))))\
-{\
-ast_log(LOG_ERROR, "Error retrieving the redis context from thread\n");\
-return CLI_FAILURE;\
-}\
+/* For CLI helpers (return CLI_FAILURE on failure) */
+#define get_safe_redis_context_for_cli_as(name)                      \
+    redisContext *name = NULL;                                       \
+    do {                                                             \
+        redisContext **__pp =                                        \
+            ast_threadstorage_get(&redis_instance, sizeof(void *));  \
+        if (!__pp || !(*__pp)) {                                     \
+            ast_log(LOG_ERROR, "No redis context in thread\n");      \
+            return CLI_FAILURE;                                      \
+        }                                                            \
+        name = *__pp;                                                \
+    } while (0)
 
 
 #define replyHaveError(reply) (reply != NULL && reply->type == REDIS_REPLY_ERROR)
@@ -200,24 +212,25 @@ AST_THREADSTORAGE_CUSTOM(redis_instance, redis_connect, redis_disconnect)
  */
 static int redis_connect(void * data)
 {
-    redisContext * redis_context = NULL;
-    redis_context = redisConnectWithTimeout(hostname, port, timeout);
-    if (redis_context == NULL) {
-        ast_log(AST_LOG_ERROR,
-                "Couldn't establish connection. Reason: UNKNOWN\n");
+    redisContext *ctx = redisConnectWithTimeout(hostname, port, timeout);
+    if (!ctx || ctx->err) {
+        ast_log(LOG_ERROR, "Redis connect failed: %s\n",
+                ctx ? ctx->errstr : "UNKNOWN");
+        if (ctx)
+            redisFree(ctx);
         return -1;
     }
 
-    if(redis_context->err != 0){
+    if(ctx->err != 0){
         ast_log(AST_LOG_ERROR,
-                "Couldn't establish connection. Reason: %s\n", redis_context->errstr);
+                "Couldn't establish connection. Reason: %s\n", ctx->errstr);
         return -1;
     }
 
     redisReply * reply = NULL;
     if (strnlen(password, STR_CONF_SZ) != 0) {
         ast_log(AST_LOG_DEBUG, "REDIS : Authenticating...\n");
-        reply = redisCommand(redis_context,"AUTH %s", password);
+        reply = redisCommand(ctx,"AUTH %s", password);
         if (replyHaveError(reply)) {
             ast_log(LOG_ERROR, "Unable to authenticate. Reason: %s\n", reply->str);
             return -1;
@@ -228,7 +241,7 @@ static int redis_connect(void * data)
 
     if (strnlen(dbname, STR_CONF_SZ) != 0) {
         ast_log(AST_LOG_DEBUG, "Selecting DB %s\n", dbname);
-        reply = redisLoggedCommand(redis_context,"SELECT %s", dbname);
+        reply = redisLoggedCommand(ctx,"SELECT %s", dbname);
         if (replyHaveError(reply)) {
             ast_log(AST_LOG_ERROR, "Unable to select DB %s. Reason: %s\n", dbname, reply->str);
             return -1;
@@ -237,53 +250,17 @@ static int redis_connect(void * data)
         freeReplyObject(reply);
     }
 
-    memcpy(data, redis_context, sizeof(redisContext));
-    ast_free(redis_context);
+    /* Keep only the pointer in TLS */
+    *(redisContext **)data = ctx;
     return 0;
 }
 
-static void redis_disconnect(void *data){
-    redisContext * redis_context = data;
-
-    if (redis_context == NULL)
-        return;
-
-    if (redis_context->fd > 0)
-        close(redis_context->fd);
-    if (redis_context->obuf != NULL)
-        sdsfree(redis_context->obuf);
-    if (redis_context->reader != NULL){
-        if (redis_context->reader->reply != NULL && redis_context->reader->fn && redis_context->reader->fn->freeObject)
-            redis_context->reader->fn->freeObject(redis_context->reader->reply);
-        if (redis_context->reader->buf != NULL)
-            sdsfree(redis_context->reader->buf);
-        ast_free(redis_context->reader);
-    } // = redisReaderFree(redis_context->reader);
-
-
-#if HIREDIS_MAJOR == 0 && HIREDIS_MINOR > 12
-    if (redis_context->tcp.host)
-        ast_free(redis_context->tcp.host);
-    if (redis_context->tcp.source_addr)
-        ast_free(redis_context->tcp.source_addr);
-    if (redis_context->timeout)
-        ast_free(redis_context->timeout);
-#endif
-
-#if HIREDIS_MAJOR == 0 && HIREDIS_MINOR == 13 && HIREDIS_PATCH == 0
-    if (redis_context->unix.path){
-        ast_free(redis_context->unix.path);
-    }
-#endif
-
-#if HIREDIS_MAJOR == 0 && HIREDIS_MINOR == 13 && HIREDIS_PATCH > 0
-    if (redis_context->unix_sock.path){
-        ast_free(redis_context->unix_sock.path);
-    }
-#endif
-
-    ast_free(redis_context);
-    return;
+static void redis_disconnect(void *data)
+{
+    redisContext *ctx = *(redisContext **)data;
+    if (ctx)
+        redisFree(ctx);
+    *(redisContext **)data = NULL;
 }
 
 /*!
@@ -1003,13 +980,18 @@ static int unload_module(void)
 
     if (ast_true(bgsave)) {
         redisReply * reply = NULL;
-        redisContext * redis_context = NULL;
-        if (!(redis_context = ast_threadstorage_get(&redis_instance, sizeof(redisContext))))
-        {
-            ast_log(AST_LOG_ERROR, "Error retrieving the redis context from thread\n");
+        redisContext **ctxp =
+            ast_threadstorage_get(&redis_instance, sizeof(void *));
+        if (!ctxp || !*ctxp) {
+            ast_log(AST_LOG_ERROR,
+                    "Error retrieving the redis context from thread\n");
             return -1;
         }
-        ast_log(AST_LOG_NOTICE, "Sending BGSAVE before closing connection.\n");
+        /* step 2: dereference once to get the real redisContext * */
+        redisContext *redis_context = *ctxp;
+
+        ast_log(AST_LOG_NOTICE,
+                "Sending BGSAVE before closing connection.\n");
         reply = redisLoggedCommand(redis_context, "BGSAVE");
         ast_log(AST_LOG_NOTICE, "Closing connection.\n");
         freeReplyObject(reply);

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -309,6 +309,8 @@ static char * get_reply_value_as_str(redisReply *reply){
                         snprintf(value, value_new_sz, "%s,%s", old_value, element_value);
                         ast_free(old_value);
                     }
+
+                    ast_free(element_value);
                 }
 
                 break;
@@ -323,17 +325,35 @@ static char * get_reply_value_as_str(redisReply *reply){
 }
 
 static void get_reply_value_for_hash(redisReply *reply, char **colnames, char **value) {
+
+    /* Initialize outputs */
+    *colnames = NULL;
+    *value = NULL;
+
+    /* Handle NULL reply case */
+    if (reply == NULL) {
+        ast_debug(1, "NULL reply passed to get_reply_value_for_hash()\n");
+        return;
+    }
+
     if (reply != NULL) {
         for(size_t i = 0; i < reply->elements; ++i) {
             char * old_value = NULL;
             redisReply * element = reply->element[i];
 
-            char * element_value = get_reply_value_as_str(element);
+            char *element_value = get_reply_value_as_str(element);
             size_t element_sz = (size_t)element->len;
 
             if (i == 0) {
                 size_t value_sz = element_sz + 1;
                 *colnames = (char*)ast_malloc(value_sz);
+
+                if (!*colnames) {
+                    ast_log(LOG_ERROR, "Memory allocation failed\n");
+                    ast_free(element_value);
+                    return;
+                }
+
                 snprintf(*colnames, value_sz, "%s", element_value);
             }
             else if (i == 1) {
@@ -358,6 +378,7 @@ static void get_reply_value_for_hash(redisReply *reply, char **colnames, char **
 
                 ast_free(old_value);
             }
+            ast_free(element_value);
         }
     }
 
@@ -559,7 +580,7 @@ static int function_redis_get_hash(struct ast_channel *chan, const char *cmd,
     } else {
         char * value = NULL;
         char * colnames = NULL;
-        
+    
         get_reply_value_for_hash(reply, &colnames, &value);
         
         if(value && colnames) {

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -853,7 +853,7 @@ static char *handle_cli_redis_set(struct ast_cli_entry *e, int cmd, struct ast_c
 
 
     redisReply * reply = NULL;
-    get_safe_redis_context_for_cli_as(redis_context)
+    get_safe_redis_context_for_cli_as(redis_context);
 
     reply = redisLoggedCommand(redis_context,"SET %s %s", args->argv[2], args->argv[3]);
     if (reply == NULL){

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -574,9 +574,11 @@ static int function_redis_get_hash(struct ast_channel *chan, const char *cmd,
             pbx_builtin_setvar_helper(chan, "~ODBCFIELDS~", "");
             pbx_builtin_setvar_helper(chan, "REDIS_HASH_EXISTS", "no");
         }
-        
-        freeReplyObject(reply);
+            
     }
+
+    freeReplyObject(reply);
+
     return 0;
 }
 
@@ -626,9 +628,8 @@ static int function_redis_command(struct ast_channel *chan, const char *cmd,
         }
     }
 
-    if (reply) {
-        freeReplyObject(reply);
-    }
+    freeReplyObject(reply);
+
     pbx_builtin_setvar_helper(chan, "REDIS_RESULT", return_buffer);
 
     return 0;
@@ -678,8 +679,10 @@ static int function_redis_read(struct ast_channel *chan, const char *cmd,
             pbx_builtin_setvar_helper(chan, "REDIS_RESULT", value);
             ast_free(value);
         }
-        freeReplyObject(reply);
     }
+
+    freeReplyObject(reply);
+    
     return 0;
 }
 

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -233,6 +233,8 @@ static int redis_connect(void * data)
         reply = redisCommand(ctx,"AUTH %s", password);
         if (replyHaveError(reply)) {
             ast_log(LOG_ERROR, "Unable to authenticate. Reason: %s\n", reply->str);
+            freeReplyObject(reply);
+            redisFree(ctx);
             return -1;
         }
         ast_log(AST_LOG_DEBUG, "REDIS : Authenticated.\n");
@@ -244,6 +246,8 @@ static int redis_connect(void * data)
         reply = redisLoggedCommand(ctx,"SELECT %s", dbname);
         if (replyHaveError(reply)) {
             ast_log(AST_LOG_ERROR, "Unable to select DB %s. Reason: %s\n", dbname, reply->str);
+            freeReplyObject(reply);
+            redisFree(ctx);
             return -1;
         }
         ast_log(AST_LOG_DEBUG, "Database %s selected.\n", dbname);
@@ -621,6 +625,8 @@ static int function_redis_command(struct ast_channel *chan, const char *cmd,
             pbx_builtin_setvar_helper(chan, "REDIS_ERROR", "Error in reply as str");
         }
     }
+
+    freeReplyObject(reply);
     pbx_builtin_setvar_helper(chan, "REDIS_RESULT", return_buffer);
 
     return 0;
@@ -760,6 +766,8 @@ static int function_redis_exists(struct ast_channel *chan, const char *cmd,
         ast_log(AST_LOG_WARNING, "REDIS EXIST failed\n");
         strncpy(return_buffer, "0", rtn_buff_len);
     }
+
+    freeReplyObject(reply);
     pbx_builtin_setvar_helper(chan, "REDIS_RESULT", return_buffer);
 
     return 0;
@@ -948,7 +956,7 @@ static char *handle_cli_redis_show(struct ast_cli_entry *e, int cmd, struct ast_
         for (i = 0; i < reply->elements; i++) {
             get_reply = redisLoggedCommand(redis_context, "GET %s", reply->element[i]->str);
             if (get_reply != NULL) {
-                if (replyHaveError(reply)) {
+                if (replyHaveError(get_reply)) {
                     ast_cli(args->fd, "%s\n", reply->str);
                 } else {
                     char *value = get_reply_value_as_str(get_reply);

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -626,7 +626,9 @@ static int function_redis_command(struct ast_channel *chan, const char *cmd,
         }
     }
 
-    freeReplyObject(reply);
+    if (reply) {
+        freeReplyObject(reply);
+    }
     pbx_builtin_setvar_helper(chan, "REDIS_RESULT", return_buffer);
 
     return 0;

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -957,7 +957,7 @@ static char *handle_cli_redis_show(struct ast_cli_entry *e, int cmd, struct ast_
             get_reply = redisLoggedCommand(redis_context, "GET %s", reply->element[i]->str);
             if (get_reply != NULL) {
                 if (replyHaveError(get_reply)) {
-                    ast_cli(args->fd, "%s\n", reply->str);
+                    ast_cli(args->fd, "%s\n", get_reply->str);
                 } else {
                     char *value = get_reply_value_as_str(get_reply);
                     if (value) {

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -987,7 +987,7 @@ static char *handle_cli_redis_show(struct ast_cli_entry *e, int cmd, struct ast_
                 } else {
                     char *value = get_reply_value_as_str(get_reply);
                     if (value) {
-                        ast_cli(args->fd, "%-50s: %-25s\n", get_reply->element[i]->str, value);
+                        ast_cli(args->fd, "%-50s: %-25s\n", reply->element[i]->str, value);
                         ast_free(value);
                     }
                 }


### PR DESCRIPTION
Removes the memcpy/manual‐free bug

Uses sizeof(void *) for every ast_threadstorage_get()

Dereferences exactly once in both helper macros

Adds the safety *(redisContext **)data = NULL; in redis_disconnect()

Adds the missing freeReplyObject(reply); on all error exits